### PR TITLE
Makefile changes for automated build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX_FLAGS=-O0 -std=c++11 -DNDEBUG
+CXX_FLAGS=-O3 -std=c++11 -DNDEBUG
 INCLUDE_PATH=-I./include/
 
 ifeq ($(CXX),icpc)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX_FLAGS=-O3 -std=c++11 -DNDEBUG
+CXX_FLAGS=-O0 -std=c++11 -DNDEBUG
 INCLUDE_PATH=-I./include/
 
 ifeq ($(CXX),icpc)
@@ -13,6 +13,8 @@ endif
 endif
 endif
 
+all: lib/libhptt.so lib/libhptt.a
+
 avx: 
 	${MAKE} clean 
 	${MAKE} avx2
@@ -26,7 +28,7 @@ scalar:
 	${MAKE} clean 
 	${MAKE} scalar2
 
-avx2:CXX_FLAGS+=-mavx -DHPTT_ARCH_AVX
+avx2: CXX_FLAGS+=-mavx -DHPTT_ARCH_AVX
 avx2: all
 arm2: CXX_FLAGS+=-mfpu=neon -DHPTT_ARCH_ARM
 arm2: all
@@ -38,7 +40,6 @@ SRC=$(wildcard ./src/*.cpp)
 OBJ=$(SRC:.cpp=.o)
 SHARED_OBJ=$(SRC:.cpp=.so)
 
-all: lib/libhptt.so lib/libhptt.a
 
 lib/libhptt.so: ${SHARED_OBJ}
 	mkdir -p lib
@@ -48,10 +49,10 @@ lib/libhptt.a: ${OBJ}
 	mkdir -p lib
 	ar rvs lib/libhptt.a ${OBJ}
 
-%.o: %.cpp
+${OBJ}: %.o: %.cpp
 	${CXX} ${CXX_FLAGS} ${INCLUDE_PATH} -c $< -o $@
 
-%.so: %.cpp
+${SHARED_OBJ}: %.so: %.cpp
 	${CXX} ${CXX_FLAGS} -fPIC ${INCLUDE_PATH} -c $< -o $@
 
 doc:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX_FLAGS=-O3 -std=c++11 -fPIC -DNDEBUG
+CXX_FLAGS=-O3 -std=c++11 -DNDEBUG
 INCLUDE_PATH=-I./include/
 
 ifeq ($(CXX),icpc)
@@ -36,17 +36,26 @@ scalar2: all
 
 SRC=$(wildcard ./src/*.cpp)
 OBJ=$(SRC:.cpp=.o)
+SHARED_OBJ=$(SRC:.cpp=.so)
 
-all: ${OBJ}
+all: lib/libhptt.so lib/libhptt.a
+
+lib/libhptt.so: ${SHARED_OBJ}
 	mkdir -p lib
-	${CXX} ${OBJ} ${CXX_FLAGS} -o lib/libhptt.so -shared
+	${CXX} ${SHARED_OBJ} ${CXX_FLAGS} -o lib/libhptt.so -shared
+
+lib/libhptt.a: ${OBJ}
+	mkdir -p lib
 	ar rvs lib/libhptt.a ${OBJ}
 
 %.o: %.cpp
 	${CXX} ${CXX_FLAGS} ${INCLUDE_PATH} -c $< -o $@
 
+%.so: %.cpp
+	${CXX} ${CXX_FLAGS} -fPIC ${INCLUDE_PATH} -c $< -o $@
+
 doc:
 	doxygen
 
 clean:
-	rm -rf src/*.o lib/libhptt.so lib/libhptt.a
+	rm -rf ${OBJ} ${SHARED_OBJ} lib/libhptt.so lib/libhptt.a


### PR DESCRIPTION
I'd like to propose these modifications to the build system for HPTT. They are mostly minor, except that object files for the static library are built separately without -fPIC. This change is necessary to get the static library to work on my machine and I think is the correct way to build the two libraries (its what we are doing in CTF). Also tried to get persistence of up-to-date object files between builds working. Feel free to take/modify or leave aside.