### PR TITLE
update python interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ data/
 html/
 latex/
 old/
+
+*.a
+*.so
+pythonAPI/hptt/__pycache__/
+pythonAPI/hptt\.egg-info/
+pythonAPI/hptt/hptt\.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ old/
 
 *.a
 *.so
-pythonAPI/hptt/__pycache__/
-pythonAPI/hptt\.egg-info/
-pythonAPI/hptt/hptt\.cfg
+
+**/__pycache__
+**/.pytest_cache
+**/*\.egg-info/
+**/hptt\.cfg
+

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(CXX),icpc)
 CXX_FLAGS += -qopenmp -xhost 
 else
 ifeq ($(CXX),g++)
-CXX_FLAGS += -fopenmp -mcpu=native 
+CXX_FLAGS += -fopenmp -march=native 
 else
 ifeq ($(CXX),clang++)
 CXX_FLAGS += -fopenmp -march=native

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ with the difference being that HPTT can also update the output tensor.
 
     tensorTranspose( perm, alpha, A, numThreads=-1)
 
-See docstring for additional information. There is also the drop-in ``numpy.transpose`` replacement which calls these functions for you:
+See docstring for additional information. Based on those there are also the following drop-in replacements for ``numpy`` functions:
 
     hptt.transpose(A, axes)
+    hptt.ascontiguousarray(A)
+    hptt.asfortranarray(A)
 
 Installation should be straight forward via:
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,20 @@ with the difference being that HPTT can also update the output tensor.
 
     tensorTranspose( perm, alpha, A, numThreads=-1)
 
-See docstring for additional information.
+See docstring for additional information. There is also the drop-in ``numpy.transpose`` replacement which calls these functions for you:
+
+    hptt.transpose(A, axes)
 
 Installation should be straight forward via:
 
     cd ./pythonAPI
     python setup.py install
 
-At this point you should be able to import the 'hptt' package within your python scripts.
+or 
+
+    pip install -U .
+
+if you want a ``pip`` managed install. At this point you should be able to import the 'hptt' package within your python scripts.
 
 The python interface also offers support for:
 

--- a/pythonAPI/hptt/__init__.py
+++ b/pythonAPI/hptt/__init__.py
@@ -1,11 +1,20 @@
 """HPTT - Tensor Transposition Module based on the C++ High-Performance Tensor
 Transposition library (HPTT)"""
 
-from .hptt import (tensorTransposeAndUpdate, tensorTranspose, equal, transpose)
+from .hptt import (
+    tensorTransposeAndUpdate,
+    tensorTranspose,
+    equal,
+    transpose,
+    ascontiguousarray,
+    asfortranarray,
+)
 
 __all__ = [
     'tensorTransposeAndUpdate',
     'tensorTranspose',
     'equal',
     'transpose',
+    'ascontiguousarray',
+    'asfortranarray',
 ]

--- a/pythonAPI/hptt/__init__.py
+++ b/pythonAPI/hptt/__init__.py
@@ -1,3 +1,11 @@
-#!/usr/bin/env python
-"""HPTT - Tensor Transposition Module based on the C++ High-Performance Tensor Transposition library (HPTT)"""
-from hptt import *
+"""HPTT - Tensor Transposition Module based on the C++ High-Performance Tensor
+Transposition library (HPTT)"""
+
+from .hptt import (tensorTransposeAndUpdate, tensorTranspose, equal, transpose)
+
+__all__ = [
+    'tensorTransposeAndUpdate',
+    'tensorTranspose',
+    'equal',
+    'transpose',
+]

--- a/pythonAPI/hptt/hptt.py
+++ b/pythonAPI/hptt/hptt.py
@@ -1,97 +1,61 @@
 import numpy as np
-import multiprocessing
+import psutil
 import ctypes
 from ctypes import cdll
 import os
 import random
 
-HPTT_ROOT = ""
+
+if 'OMP_NUM_THREADS' in os.environ:
+    DEFAULT_THREADS = int(os.environ['OMP_NUM_THREADS'])
+else:
+    DEFAULT_THREADS = psutil.cpu_count(logical=False)
+
 try:
     HPTT_ROOT = os.environ['HPTT_ROOT']
-except:
-    print "[HPTT] ERROR: HPTT_ROOT environment variable is not set. Point HPTT_ROOT to the folder which includes HPTT_ROOT/lib/libhptt.so"
-    exit(-1)
+except KeyError:
+    try:
+        import configparser
+        config = configparser.ConfigParser()
+        config.read(os.path.join(os.path.dirname(__file__), 'hptt.cfg'))
+        HPTT_ROOT = config['lib']['HPTT_ROOT']
+    except KeyError:
+        raise OSError("[HPTT] ERROR: 'libhptt.so' can't be found. 'HPTT_ROOT' "
+                      "is neither set as an environment variable or specified "
+                      "in the config file. It should point to the folder which"
+                      " includes '$HPTT_ROOT/lib/libhptt.so'.")
 
-# load HPTT library
-HPTTlib = cdll.LoadLibrary(HPTT_ROOT+"/lib/libhptt.so")
+
+HPTTlib = cdll.LoadLibrary(os.path.join(HPTT_ROOT, "lib", "libhptt.so"))
+
 
 def randomNumaAwareInit( A ):
-    """ 
+    """
     initializes the passed numpy.ndarray (which have to be created with
     numpy.empty) and initializes it with random data in paralle such that the
-    pages are equally distributed among the numa nodes 
+    pages are equally distributed among the numa nodes
     """
     HPTTlib.randomNumaAwareInit( ctypes.c_void_p(A.ctypes.data),
             ctypes.cast(A.ctypes.shape, ctypes.POINTER(ctypes.c_voidp)),
             ctypes.c_int32(A.ndim) )
 
 
-def tensorTranspose( perm, alpha, A, numThreads=-1):
-    """ 
-        This function computes the tensor transposition of A.
-        The tensor transposition is of the form: 
-           B[perm(0,1,2,...)] = alpha * A[0,1,2,...] + beta * B[perm(0,1,2,...)]
+def checkContiguous(X):
+    try:
+        useRowMajor, order = {
+            (True, False): (1, 'C'),
+            (False, True): (0, 'F'),
+        }[X.flags['C_CONTIGUOUS'], X.flags['F_CONTIGUOUS']]
+    except KeyError:
+        raise ValueError("Tensor is neither 'C' or 'F' contiguous.")
 
-        where alpha and beta are scalors and A, and B correspond to arbitrary
-        dimensional arrays (i.e., tensors). The dimensionality of A, and B
-        depends on their indices (which need to be separated by commas).
+    return useRowMajor, order
 
-        Parameter:
-        -------------
-        A: multi-dimensional numpy array
-        alpha: scalar
-        perm: tuple of ints. perm[i] = j means that A's j-th axis becomes B's i-th axis
 
-        Example:
-        ------------
-        For instance, the tensor transposition B[m1,n1,m2] = 1.3 * A[m2,n1,m1];
-        would be represented as: tensorTranspose([2,1,0], 1.3, A).
-
+def tensorTransposeAndUpdate(perm, alpha, A, beta, B, numThreads=-1):
     """
-    if( numThreads < 0 ):
-        numThreads = max(1, multiprocessing.cpu_count()/2)
-    order = 'C'
-    useRowMajor = 1 
-    if( A.flags['F_CONTIGUOUS'] ):
-        order = 'F'
-        useRowMajor = 0
-    Ashape = A.shape
-    Bshape = [Ashape[i] for i in perm]
-    B = np.empty(Bshape, dtype=A.dtype, order=order)
-
-    permc = ctypes.cast((ctypes.c_int32 * len(perm))(*perm), ctypes.POINTER(ctypes.c_voidp))
-    dataA = ctypes.c_void_p(A.ctypes.data)
-    sizeA = ctypes.cast((ctypes.c_int32 * len(A.ctypes.shape))(*Ashape), ctypes.POINTER(ctypes.c_voidp))
-    outerSizeA = sizeA
-
-    dataB = ctypes.c_void_p(B.ctypes.data)
-    sizeB = ctypes.cast((ctypes.c_int32 * len(B.ctypes.shape))(*Bshape), ctypes.POINTER(ctypes.c_voidp))
-    outerSizeB = sizeB
-
-    if( A.dtype == 'float32' ):
-        HPTTlib.sTensorTranspose(permc, ctypes.c_int32(A.ndim),
-                ctypes.c_float(alpha), dataA, sizeA, outerSizeA,
-                ctypes.c_float(0.0),   dataB,        outerSizeB,
-                ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
-    elif( A.dtype == 'float64' ):
-        HPTTlib.dTensorTranspose(permc, ctypes.c_int32(A.ndim),
-                ctypes.c_double(alpha), dataA, sizeA, outerSizeA,
-                ctypes.c_double(0.0),   dataB,        outerSizeB,
-                ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
-    elif( A.dtype == 'complex64' ):
-        print "Data type not yet supported."
-    elif( A.dtype == 'complex128' ):
-        print "Data type not yet supported."
-    else:
-        raise ValueError('[HPTT] ERROR: unkown datatype')
-
-    return B
-
-
-def tensorTransposeAndUpdate( perm, alpha, A, beta, B, numThreads=-1):
-    """ 
         This function computes the tensor transposition of A.
-        The tensor transposition is of the form: 
+        The tensor transposition is of the form:
            B[perm(0,1,2,...)] = alpha * A[0,1,2,...] + beta * B[perm(0,1,2,...)]
 
         where alpha and beta are scalors and A, and B correspond to arbitrary
@@ -111,48 +75,106 @@ def tensorTransposeAndUpdate( perm, alpha, A, beta, B, numThreads=-1):
         For instance, the tensor transposition B[m1,n1,m2] = 1.3 * A[m2,n1,m1] + 1.2 * B[m1,n1,m2];
         would be represented as: tensorTranspose([2,1,0], 1.3, A, 1.2, B).
     """
-
-    if(A.dtype != B.dtype ):
+    if A.dtype != B.dtype:
         raise ValueError('ERROR: the data type of A and B does not match.')
 
-    if( numThreads < 0 ):
-        numThreads = max(1, multiprocessing.cpu_count()/2)
+    useRowMajor, order = checkContiguous(A)
+    if checkContiguous(B) != (useRowMajor, order):
+        raise ValueError("Tensors do not have matching C or F orders.")
 
-    order = 'C'
-    useRowMajor = 1
-    if( A.flags['F_CONTIGUOUS'] ):
-        order = 'F'
-        useRowMajor = 0
+    if numThreads < 0:
+        numThreads = max(1, DEFAULT_THREADS)
+
+    # setup A ctypes
     Ashape = A.shape
-    Bshape = B.shape
-
-    permc = ctypes.cast((ctypes.c_int32 * len(perm))(*perm), ctypes.POINTER(ctypes.c_voidp))
     dataA = ctypes.c_void_p(A.ctypes.data)
-    sizeA = ctypes.cast((ctypes.c_int32 * len(A.ctypes.shape))(*Ashape), ctypes.POINTER(ctypes.c_voidp))
+    sizeA = ctypes.cast((ctypes.c_int32 * len(A.ctypes.shape))(*Ashape),
+                        ctypes.POINTER(ctypes.c_voidp))
     outerSizeA = sizeA
+
+    # setup B ctypes
+    Bshape = B.shape
     dataB = ctypes.c_void_p(B.ctypes.data)
-    sizeB = ctypes.cast((ctypes.c_int32 * len(B.ctypes.shape))(*Bshape), ctypes.POINTER(ctypes.c_voidp))
+    sizeB = ctypes.cast((ctypes.c_int32 * len(B.ctypes.shape))(*Bshape),
+                        ctypes.POINTER(ctypes.c_voidp))
     outerSizeB = sizeB
 
-    if( A.dtype == 'float32' ):
-        HPTTlib.sTensorTranspose(permc, ctypes.c_int32(A.ndim),
-                ctypes.c_float(alpha), dataA, sizeA, outerSizeA,
-                ctypes.c_float(beta),  dataB,        outerSizeB,
+    # setup perm ctypes
+    permc = ctypes.cast((ctypes.c_int32 * len(perm))(*perm),
+                        ctypes.POINTER(ctypes.c_voidp))
+
+    # dispatch to the correct dtype function
+    try:
+        tranpose_fn, scalar_fn = {
+            'float32': (HPTTlib.sTensorTranspose, ctypes.c_float),
+            'float64': (HPTTlib.dTensorTranspose, ctypes.c_double),
+            'complex64': (HPTTlib.cTensorTranspose, ctypes.c_float),
+            'complex128': (HPTTlib.zTensorTranspose, ctypes.c_double),
+        }[str(A.dtype)]
+    except KeyError:
+        raise ValueError("Unsupported dtype: {}.".format(A.dtype))
+
+    # tranpose!
+    tranpose_fn(permc, ctypes.c_int32(A.ndim),
+                scalar_fn(alpha), dataA, sizeA, outerSizeA,
+                scalar_fn(0.0), dataB, outerSizeB,
                 ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
-    elif( A.dtype == 'float64' ):
-        HPTTlib.dTensorTranspose(permc, ctypes.c_int32(A.ndim),
-                ctypes.c_double(alpha), dataA, sizeA, outerSizeA,
-                ctypes.c_double(beta),  dataB,        outerSizeB,
-                ctypes.c_int32(numThreads), ctypes.c_int32(useRowMajor))
-    elif( A.dtype == 'complex64' ):
-        print "Data type not yet supported."
-    elif( A.dtype == 'complex128' ):
-        print "Data type not yet supported."
-    else:
-        raise ValueError('[HPTT] ERROR: unkown datatype')
+
+
+def tensorTranspose(perm, alpha, A, numThreads=-1):
+    """
+        This function computes the tensor transposition of A.
+        The tensor transposition is of the form:
+           B[perm(0,1,2,...)] = alpha * A[0,1,2,...] + beta * B[perm(0,1,2,...)]
+
+        where alpha and beta are scalors and A, and B correspond to arbitrary
+        dimensional arrays (i.e., tensors). The dimensionality of A, and B
+        depends on their indices (which need to be separated by commas).
+
+        Parameter:
+        -------------
+        A: multi-dimensional numpy array
+        alpha: scalar
+        perm: tuple of ints. perm[i] = j means that A's j-th axis becomes B's i-th axis
+
+        Example:
+        ------------
+        For instance, the tensor transposition B[m1,n1,m2] = 1.3 * A[m2,n1,m1];
+        would be represented as: tensorTranspose([2,1,0], 1.3, A).
+
+    """
+    order = 'C' if A.flags['C_CONTIGUOUS'] else 'F'
+    B = np.empty([A.shape[i] for i in perm], dtype=A.dtype, order=order)
+
+    tensorTransposeAndUpdate(perm, alpha, A, 0.0, B, numThreads=numThreads)
+
+    return B
+
+
+def transpose(a, axes=None):
+    """Drop-in for ``numpy.transpose``. Permute the dimensions of an array.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array.
+    axes : list of ints, optional
+        By default, reverse the dimensions, otherwise permute the axes
+        according to the values given.
+
+    Returns
+    -------
+    p : ndarray
+        ``a`` with its axes permuted.
+    """
+    if axes is None:
+        axes = reversed(range(a.ndim))
+
+    return tensorTranspose(axes, 1.0, a)
+
 
 def equal(A, B, numSamples=-1):
-    """ Ensures that alle elements of A and B are pretty much equal (due to limited machine precision) 
+    """ Ensures that alle elements of A and B are pretty much equal (due to limited machine precision)
 
     Parameter:
     numSamples: number of random samples to compare (-1: all). This values is used to approximate this function and speed the result up."
@@ -161,7 +183,7 @@ def equal(A, B, numSamples=-1):
     A = np.reshape(A, A.size)
     B = np.reshape(B, B.size)
     error = 0
-    samples = range(A.size)
+    samples = list(range(A.size))
     if( numSamples != -1 ):
         samples = random.sample(samples, min(A.size,numSamples))
 

--- a/pythonAPI/setup.py
+++ b/pythonAPI/setup.py
@@ -44,6 +44,10 @@ setup(
     author_email="springer@aices.rwth-aachen.de",
     packages=["hptt"],
     package_data={'hptt': ['hptt.cfg']},
+    install_requires=[
+        'numpy',
+        'psutil',
+    ]
 )
 
 print("")

--- a/pythonAPI/setup.py
+++ b/pythonAPI/setup.py
@@ -7,17 +7,48 @@ FAIL = '\033[91m'
 WARNING = '\033[93m'
 ENDC = '\033[0m'
 
-setup(name="hptt",
-        version="1.0.0",
-        description="High-Performance Tensor Transposition",
-        author="Paul Springer",
-        author_email="springer@aices.rwth-aachen.de",
-        packages=["hptt"]
-        )
 
-print ""
+def get_hptt_root():
+    """Get the root hptt folder - prefer environment variable if is set, but
+    otherwise default to the parent directory of the python module - the
+    shared library will be checked for in any case.
+    """
+    from os.path import dirname, realpath, isfile, join
+    hptt_default = dirname(dirname(realpath(__file__)))
+    HPTT_ROOT = os.environ.get('HPTT_ROOT', hptt_default)
+    if not isfile(join(HPTT_ROOT, 'lib', 'libhptt.so')):
+        raise OSError("Could not find $HPTT_ROOT/lib/libhptt.so - please make "
+                      "HPTT_ROOT points to a directory where the shared "
+                      "library has been built.")
+    return HPTT_ROOT
+
+
+def write_config():
+    """Write a config file with the default shared library location to be
+    installed by setup.py.
+    """
+    from configparser import ConfigParser
+    config = ConfigParser()
+    config['lib'] = {'HPTT_ROOT': get_hptt_root()}
+    with open(os.path.join("hptt", "hptt.cfg"), "w") as configfile:
+        config.write(configfile)
+
+
+write_config()
+
+setup(
+    name="hptt",
+    version="1.0.0",
+    description="High-Performance Tensor Transposition",
+    author="Paul Springer",
+    author_email="springer@aices.rwth-aachen.de",
+    packages=["hptt"],
+    package_data={'hptt': ['hptt.cfg']},
+)
+
+print("")
 output = "# "+ FAIL + "IMPORTANT"+ENDC+": execute 'export HPTT_ROOT=%s/../' #"%(os.path.dirname(os.path.realpath(__file__)))
-print '#'*(len(output)-2*len(FAIL)+1)
-print output
-print '#'*(len(output)-2*len(FAIL)+1)
-print ""
+print('#'*(len(output)-2*len(FAIL)+1))
+print(output)
+print('#'*(len(output)-2*len(FAIL)+1))
+print("")

--- a/pythonAPI/tests/test_hptt.py
+++ b/pythonAPI/tests/test_hptt.py
@@ -1,0 +1,43 @@
+import pytest
+from numpy.testing import assert_allclose
+
+import numpy as np
+import hptt
+
+
+class TestTranpose:
+
+    @pytest.mark.parametrize("dtype", [
+        'float32',
+        'float64',
+        'complex64',
+        'complex128',
+    ])
+    @pytest.mark.parametrize("axes", [
+        (0, 1, 2, 3),
+        (3, 1, 2, 0),
+        (1, 0, 2, 3),
+        None,
+    ])
+    @pytest.mark.parametrize("order", [
+        'C',
+        'F',
+    ])
+    def test_against_numpy(self, dtype, axes, order):
+
+        X = np.random.randn(3, 4, 5, 6)
+        if 'complex' in dtype:
+            X = X + 1.0j * np.random.randn(3, 4, 5, 6)
+
+        X = X.astype(dtype)
+
+        if order == 'F':
+            X = np.asfortranarray(X)
+
+        XT_numpy = np.transpose(X, axes)
+        XT_hptt = hptt.transpose(X, axes)
+
+        assert_allclose(XT_numpy, XT_hptt)
+
+        assert (XT_hptt.flags['C_CONTIGUOUS'] if order == 'C' else
+                XT_hptt.flags['F_CONTIGUOUS'])


### PR DESCRIPTION
I was doing some benchmarking of ``hptt`` (looks good!) and made various convenience updates to the python interface. These are quite wide-ranging and for were my own benefit but thought they might be worth integrating into the main project.

List of changes:

- python 3 support
- install a config file with the library location (``$HPTT_ROOT`` still takes precedence but is not needed to ``import hptt``)
- enable complex support (though only will real ``alpha``/``beta``)
- add a drop-in replacement for ``numpy.transpose``
- drop-ins for ``ascontiguousarray`` and ``asfortranarray`` as well
- add python unit-tests using ``pytest``
- explicit checks for array contiguity

```python
import numpy as np
import hptt

A = np.random.rand(2, 3, 4, 5)
perm = (3, 0, 2, 1)

AT_numpy = np.transpose(A, perm)
AT_hptt = hptt.transpose(A, perm)

np.allclose(AT_numpy, AT_hptt)
True
```