### PR TITLE
Add support for tests with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,3 +58,7 @@ set(HPTT_INCLUDES
 
 install(FILES ${HPTT_INCLUDES}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+
+if(BUILD_TESTING)
+	add_subdirectory(testframework)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ install(TARGETS hptt
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
         ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
-set(HPTT_INCLUDES 
-    include/compute_node.h 
-    include/hptt_types.h 
-    include/hptt.h 
-    include/macros.h 
-    include/plan.h 
-    include/utils.h 
+set(HPTT_INCLUDES
+    include/compute_node.h
+    include/hptt_types.h
+    include/hptt.h
+    include/macros.h
+    include/plan.h
+    include/utils.h
     include/transpose.h)
 
 install(FILES ${HPTT_INCLUDES}

--- a/testframework/CMakeLists.txt
+++ b/testframework/CMakeLists.txt
@@ -1,0 +1,36 @@
+enable_testing()
+
+set(COMMON_CXX_FLAGS "-O3 -std=c++11")
+
+# AppleClang does not support OpenMP, therefore not MATCHES but STREQUAL:
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS} -fopenmp")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS} -qopenmp -xhost")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # PPC does not support -march=
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|ppc64|ppc64le" OR CMAKE_OSX_ARCHITECTURES MATCHES "ppc|ppc64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS} -fopenmp -mtune=native")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS} -fopenmp -march=native")
+  endif()
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_CXX_FLAGS}")
+endif()
+
+set(TEST_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
+include_directories(
+  ../include
+  ../benchmark
+)
+
+set(testframework_SRCS
+  testframework.cpp
+  ../benchmark/reference.cpp
+)
+
+add_executable(testframework ${testframework_SRCS})
+target_link_libraries(hptt INTERFACE "-L../lib/")
+
+add_test(testframework ${TEST_PATH}/testframework)


### PR DESCRIPTION
Preliminary implementation of tests with CMake.
_Preliminary,_ because tests are broken: https://github.com/springer13/hptt/issues/18 https://github.com/springer13/hptt/issues/23

P. S. Makefile for tests should be fixed too, it will not work on PPC now and also seems to use wrong include path here: https://github.com/springer13/hptt/blob/942538649b51ff14403a0c73a35d9825eab2d7de/testframework/Makefile#L24